### PR TITLE
Allow incomplete style arguments

### DIFF
--- a/src/fitch.typ
+++ b/src/fitch.typ
@@ -125,6 +125,8 @@
   start: 1,
   style: fitch-style-default,
 ) = {
+  style = fitch-style-default + style
+
   let premises = ()
   let body = ()
   for item in nodes.pos() {


### PR DESCRIPTION
This small PR changes the behavior of the `style` argument, allowing to *override* the defaults ​​instead of writing the entire configuration. So, if the `style` is incomplete, it will be complemented with defaults.

P.S. Order of concatenation matters! `style += fitch-style-default` won't work. This is defined by the [IndexMap](https://docs.rs/indexmap/latest/indexmap/map/struct.IndexMap.html#impl-Extend%3C(K,+V)%3E-for-IndexMap%3CK,+V,+S%3E:~:text=If%20equivalents%20of%20a%20key%20occur%20more%20than%20once%2C%20the%20last%20corresponding%20value%20prevails), which is used in Typst dictionary [implementation](https://github.com/typst/typst/blob/main/crates/typst-library/src/foundations/dict.rs#L80).